### PR TITLE
Show screening types in `JobInfo`

### DIFF
--- a/src/types/Queue.ts
+++ b/src/types/Queue.ts
@@ -5,6 +5,8 @@ export type Status = "waiting" | "active" | "completed" | "rejected";
 
 export type Operation = "addedJob" | "changedStatus" | "removedJob";
 
+export type ScreeningType = "intern" | "instructor" | "tutor" | "projectCoach";
+
 export enum QueueChanges {
   ADDED_JOB = "addedJob",
   REMOVED_JOB = "removedJob",
@@ -31,6 +33,7 @@ export interface Subject {
 export interface StudentData extends IRawStudent {
   jitsi: string;
   subjects: { name: string; grade: { min: number; max: number } }[];
+  screeningTypes: ScreeningType[];
 }
 
 export interface JobInfo extends StudentData {

--- a/src/utils/jobUtils.ts
+++ b/src/utils/jobUtils.ts
@@ -1,10 +1,25 @@
 import crypto from "crypto";
-import { StudentData, Status } from "../types/Queue";
+import { StudentData, Status, ScreeningType } from "../types/Queue";
 import { IRawStudent } from "../types/Student";
 import { IStudentScreeningResult } from "../types/StudentScreeningResult";
 
 export const getId = (email: string) =>
   crypto.createHash("md5").update(email).digest("hex");
+
+const getScreeningType = (student: IRawStudent): ScreeningType[] => {
+  const screenings: ScreeningType[] = [];
+
+  if (student.isInstructor && student.screenings.instructor === undefined) {
+    screenings.push(student.official ? "intern" : "instructor");
+  }
+  if (student.isTutor && student.screenings.tutor === undefined) {
+    screenings.push("tutor");
+  }
+  if (student.isProjectCoach && student.screenings.projectCoach === undefined) {
+    screenings.push("projectCoach");
+  }
+  return screenings;
+};
 
 export const createJob = (id: string, student: IRawStudent): StudentData => {
   const subjects = student.subjects.map((s) => ({
@@ -18,12 +33,15 @@ export const createJob = (id: string, student: IRawStudent): StudentData => {
     max: f.max || 13,
   }));
 
+  const screeningTypes = getScreeningType(student);
+
   return {
     id,
     ...student,
     subjects,
     projectFields,
     jitsi: `https://meet.jit.si/${id}`,
+    screeningTypes,
   };
 };
 


### PR DESCRIPTION
This is done in favor of inferring the screening type on client side. In particular the student's screening frontend is accessible without real authentication hence we want to communicate as few information as possible.
This PR is a prerequisite for solving corona-school/project-user#286 since this requires identifying interns.